### PR TITLE
style: Estilização da tela inicial do administrador

### DIFF
--- a/app/Http/Controllers/AdministratorController.php
+++ b/app/Http/Controllers/AdministratorController.php
@@ -12,7 +12,8 @@ class AdministratorController extends Controller
         return view('administrator.home');
     }
     
-    public function login(){
+    public function login()
+    {
         return view('login');
     }
 

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1,0 +1,57 @@
+body {
+    background-color: #f5f9fd;
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+}
+
+.title {
+    font-weight: bold;
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    margin-left: 20px;
+}
+
+.container {
+    background-color: #fff;
+    border-radius: 8px;
+    padding: 30px;
+    max-width: 800px;
+    margin: 0 auto;
+    box-shadow: 0 0 8px rgba(0,0,0,0.1);
+}
+
+.center-box {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.center-box .btn {
+    margin: 0 10px;
+    padding: 10px 20px;
+    font-weight: bold;
+    background-color: #3490dc;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.center-box .btn:hover {
+    background-color: #2779bd;
+}
+
+.overview {
+    background-color: #eef3f7;
+    padding: 20px;
+    border-radius: 8px;
+}
+
+.stat {
+    margin-bottom: 10px;
+    font-size: 1.1rem;
+}
+.logo{
+    max-width: 20px;
+    max-height: 20px;
+}

--- a/resources/views/administrator/home.blade.php
+++ b/resources/views/administrator/home.blade.php
@@ -7,13 +7,48 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Lemma - Soluções em Linguística</title>
     <link rel="icon" href="https://cdn.interago.com.br/img/png/w_0_q_8/429/mc/Logo%20e%20favicon//lemma_favicon">
+    <link rel="stylesheet" href="{{ asset('css/home.css') }}">
+
+  
 </head>
 
 <body>
-    <h2>Home</h2>
+
+    {{-- Título Home fora da caixa --}}
+    <div class="title">Home </div>
     
-    <a href="{{ route('administrator.teachers') }}">Professores</a><br>
-    <a href="{{ route('administrator.students') }}">Alunos</a><br>
+        <div class="center-box">
+            <a href="{{ route('administrator.teachers') }}">
+                <button class="btn">Professores</button>
+            </a>
+            <a href="{{ route('administrator.students') }}">
+                <button class="btn">Alunos</button>
+            </a>
+        </div>
+
+        <hr>
+
+        {{-- Visão Geral embaixo dos botões --}}
+        <div class="overview">
+            <h3>Visão Geral</h3>
+
+            <div class="stat">
+                <span>Professores cadastrados:</span>
+                <span>: <strong>{{ $professoresCount ?? '16' }}</strong></span>
+            </div>
+
+            <div class="stat">
+                <span>Alunos cadastrados:</span>
+                <span>: <strong>{{ $alunosCount ?? '250' }}</strong></span>
+            </div>
+        </div>
+    </div>
+
 </body>
+<footer>
+    <div class="footer">
+        <p>© 2025 Lemma - Soluções em Linguística. - QuantIT Todos os direitos reservados.</p>
+    </div>
+
 
 </html>


### PR DESCRIPTION
## Tipo de mudança

- [ ] Correção de um problema (fix)
- [ ] Nova funcionalidade (feat)
- [ ] Refatoração (refactor)
- [ ] Documentação (docs)
- [ ] Testes (test)
- [X] Outro (chore): estilização da view `home`

## Resumo das mudanças

- Estruturação da interface da página `home` com layout dividido em duas seções principais:
  - Cabeçalho com o título "Home" fixado no canto superior esquerdo;
  - Dois botões centrais para navegação rápida: **Professores** e **Alunos**;
    - Botões possuem efeito de hover, mudando de cor quando o cursor é posicionado em cima.
  - Sessão inferior com título "Visão Geral" contendo dois contadores:
    - Adicionados placeholders para os valores dos contadores, com suporte a exibição dinâmica via Laravel Blade.
    - Professores cadastrados (`{{ $professoresCount ?? '16' }}`)
    - Alunos cadastrados (`{{ $alunosCount ?? '250' }}`)
- Implementado arquivo CSS externo (`home.css`) para organização do estilo visual.

> Essa estrutura melhora a usabilidade e prepara a tela para exibição de dados futuros de forma organizada e visualmente clara.

## Capturas de tela (opcional)

![image](https://github.com/user-attachments/assets/b73ca42d-5087-4e23-850f-57e925c3e56c)
